### PR TITLE
Add a new option "enableTransition" to prevent infinite loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-lightbox",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A port >= angular5 for lightbox2",
   "main": "index.js",
   "dependencies": {},

--- a/src/lightbox-config.service.ts
+++ b/src/lightbox-config.service.ts
@@ -12,6 +12,7 @@ export class LightboxConfig {
   public disableKeyboardNav: boolean;
   public disableScrolling: boolean;
   public centerVertically: boolean;
+  public enableTransition: boolean;
   constructor() {
     this.fadeDuration = 0.7;
     this.resizeDuration = 0.5;
@@ -23,5 +24,6 @@ export class LightboxConfig {
     this.disableKeyboardNav = false;
     this.disableScrolling = false;
     this.centerVertically = false;
+    this.enableTransition = true;
   }
 }

--- a/src/lightbox.component.ts
+++ b/src/lightbox.component.ts
@@ -290,7 +290,7 @@ export class LightboxComponent implements AfterViewInit, OnDestroy, OnInit {
 
       // bind resize event to outer container
       // use enableTransition to prevent infinite loader
-      if(this.options.enableTransition){
+      if (this.options.enableTransition) {
         this._event.transitions = [];
         ['transitionend', 'webkitTransitionEnd', 'oTransitionEnd', 'MSTransitionEnd'].forEach(eventName => {
           this._event.transitions.push(

--- a/src/lightbox.component.ts
+++ b/src/lightbox.component.ts
@@ -289,16 +289,21 @@ export class LightboxComponent implements AfterViewInit, OnDestroy, OnInit {
       this._rendererRef.setElementStyle(this._outerContainerElem.nativeElement, 'height', `${newHeight}px`);
 
       // bind resize event to outer container
-      this._event.transitions = [];
-      ['transitionend', 'webkitTransitionEnd', 'oTransitionEnd', 'MSTransitionEnd'].forEach(eventName => {
-        this._event.transitions.push(
-          this._rendererRef.listen(this._outerContainerElem.nativeElement, eventName, (event: any) => {
-            if (event.target === event.currentTarget) {
-              this._postResize(newWidth, newHeight);
-            }
-          })
-        );
-      });
+      // use enableTransition to prevent infinite loader
+      if(this.options.enableTransition){
+        this._event.transitions = [];
+        ['transitionend', 'webkitTransitionEnd', 'oTransitionEnd', 'MSTransitionEnd'].forEach(eventName => {
+          this._event.transitions.push(
+            this._rendererRef.listen(this._outerContainerElem.nativeElement, eventName, (event: any) => {
+              if (event.target === event.currentTarget) {
+                this._postResize(newWidth, newHeight);
+              }
+            })
+          );
+        });
+      } else {
+        this._postResize(newWidth, newHeight);
+      }
     } else {
       this._postResize(newWidth, newHeight);
     }


### PR DESCRIPTION
I using ngx-lightbox for display a gallery of picture in base64 which have nearly the same dimension. To prevent when "transitionEnd" is not fire, I adding a new property to directly display picture.