### PR TITLE
Fix "Document is not defined" issue with Angular Universal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 [![Build Status](https://travis-ci.org/themyth92/ngx-lightbox.svg?branch=master)](https://travis-ci.org/themyth92/ngx-lightbox)
 
 # Ngx-Lightbox
+
 A [lighbox2](https://github.com/lokesh/lightbox2) implementation port to use with new Angular without the need for jQuery
 
 ## Version
+
 - For Angular 5, 6, 7, please use ngx-lightbox 1.x.x. `npm install ngx-lightbox@1.2.0`
 - For Angular >= 8, please use ngx-lightbox 2.x.x. `npm install ngx-lightbox@2.0.0`
 - For Angular 2, 4, please use [angular2-lightbox](https://github.com/themyth92/angular2-lightbox)
@@ -11,6 +13,7 @@ A [lighbox2](https://github.com/lokesh/lightbox2) implementation port to use wit
 ## [Demo](https://themyth92.com/project/ngx-lightbox)
 
 ## Installation
+
 `npm install --save ngx-lightbox`
 
 Update your `angular.json`
@@ -25,7 +28,9 @@ Update your `angular.json`
 ```
 
 ## Usage
+
 ### Module:
+
 Import `LightboxModule` from `ngx-lightbox`
 
 ```javascript
@@ -37,11 +42,12 @@ import { LightboxModule } from 'ngx-lightbox';
 ```
 
 ### Component
+
 1. Markup
 
 ```html
 <div *ngFor="let image of _albums; let i=index">
-  <img [src]="image.thumb" (click)="open(i)"/>
+  <img [src]="image.thumb" (click)="open(i)" />
 </div>
 ```
 
@@ -82,11 +88,11 @@ export class AppComponent {
 
 Each `object` of `album` array inside your component may contains 3 properties :
 
-Properties | Requirement | Description
-----------|-------------|------------
-src | Required | The source image to your thumbnail that you want to with use lightbox when user click on `thumbnail` image
-caption | Optional | Your caption corresponding with your image 
-thumb | Optional | Source of your thumbnail. It is being used inside your component markup so this properties depends on your naming.
+| Properties | Requirement | Description                                                                                                        |
+| ---------- | ----------- | ------------------------------------------------------------------------------------------------------------------ |
+| src        | Required    | The source image to your thumbnail that you want to with use lightbox when user click on `thumbnail` image         |
+| caption    | Optional    | Your caption corresponding with your image                                                                         |
+| thumb      | Optional    | Source of your thumbnail. It is being used inside your component markup so this properties depends on your naming. |
 
 3. Listen to lightbox event
 
@@ -128,23 +134,25 @@ export class AppComponent {
 
 Available options based on lightbox2 options
 
-Properties | Default | Description
------------|---------|------------
-fadeDuration | **0.7** seconds | *duration* starting when the **src** image is **loaded** to **fully appear** onto screen.
-resizeDuration | **0.5** seconds | *duration* starting when Lightbox container  **change** its dimension from a *default/previous image* to the *current image* when the *current image* is **loaded**.
-fitImageInViewPort | **true** | Determine whether lightbox will use the natural image *width/height*  or change the image *width/height* to fit the view of current window. Change this option to **true** to prevent problem when image too big compare to browser windows.
-positionFromTop | **20** px | The position of lightbox from the top of window browser
-showImageNumberLabel | **false** | Determine whether to show the image number to user. The default text shown is `Image IMAGE_NUMBER of ALBUM_LENGTH`
-alwaysShowNavOnTouchDevices | **false** | Determine whether to show `left/right` arrow to user on Touch devices.
-wrapAround | **false** | Determine whether to move to the start of the album when user reaches the end of album and vice versa. Set it to **true** to enable this feature.
-disableKeyboardNav | **false** | Determine whether to disable navigation using keyboard event.
-disableScrolling | **false** | If **true**, prevent the page from scrolling while Lightbox is open. This works by settings overflow hidden on the body.
-centerVertically | **false** | If **true**, images will be centered vertically to the screen.
-albumLabel | 	"Image %1 of %2" | 	The text displayed below the caption when viewing an image set. The default text shows the current image number and the total number of images in the set.
-enableTransition | **true** | Transition animation between images will be disabled if this flag set to **false**
+| Properties                  | Default          | Description                                                                                                                                                                                                                                 |
+| --------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| fadeDuration                | **0.7** seconds  | _duration_ starting when the **src** image is **loaded** to **fully appear** onto screen.                                                                                                                                                   |
+| resizeDuration              | **0.5** seconds  | _duration_ starting when Lightbox container **change** its dimension from a _default/previous image_ to the _current image_ when the _current image_ is **loaded**.                                                                         |
+| fitImageInViewPort          | **true**         | Determine whether lightbox will use the natural image _width/height_ or change the image _width/height_ to fit the view of current window. Change this option to **true** to prevent problem when image too big compare to browser windows. |
+| positionFromTop             | **20** px        | The position of lightbox from the top of window browser                                                                                                                                                                                     |
+| showImageNumberLabel        | **false**        | Determine whether to show the image number to user. The default text shown is `Image IMAGE_NUMBER of ALBUM_LENGTH`                                                                                                                          |
+| alwaysShowNavOnTouchDevices | **false**        | Determine whether to show `left/right` arrow to user on Touch devices.                                                                                                                                                                      |
+| wrapAround                  | **false**        | Determine whether to move to the start of the album when user reaches the end of album and vice versa. Set it to **true** to enable this feature.                                                                                           |
+| disableKeyboardNav          | **false**        | Determine whether to disable navigation using keyboard event.                                                                                                                                                                               |
+| disableScrolling            | **false**        | If **true**, prevent the page from scrolling while Lightbox is open. This works by settings overflow hidden on the body.                                                                                                                    |
+| centerVertically            | **false**        | If **true**, images will be centered vertically to the screen.                                                                                                                                                                              |
+| albumLabel                  | "Image %1 of %2" | The text displayed below the caption when viewing an image set. The default text shows the current image number and the total number of images in the set.                                                                                  |
+| enableTransition            | **true**         | Transition animation between images will be disabled if this flag set to **false**                                                                                                                                                          |
 
 **NOTE**: You can either override default config or during a specific opening window
+
 1. Override default config
+
 ```javascript
 import { LightboxConfig } from 'ngx-lightbox';
 
@@ -157,6 +165,7 @@ export class AppComponent {
 ```
 
 2. Set config in a specific opening window
+
 ```javascript
 import { LightboxConfig, Lightbox } from 'ngx-lightbox';
 
@@ -169,11 +178,22 @@ export class AppComponent {
 }
 ```
 
+## Angular Universal
+
+For this to work with Angular Universal, you need to have a global window object defined in your `server.js` (the one in your Angular project derived from initiating an ssr project using Angular Universal) using any `window` npm lib like [window](https://www.npmjs.com/package/window) or [domino](https://www.npmjs.com/package/domino)
+
+Add the below to your `server.js`
+
+```js
+global['window'] = window;
+```
+
 ## License
 
 MIT
 
 ## Donation
+
 Buy me a beer if you like
 
 BTC: 1MFx5waJ7Sitn961DaXe3mQXrb7pEoSJct

--- a/src/lightbox-overlay.component.ts
+++ b/src/lightbox-overlay.component.ts
@@ -1,15 +1,14 @@
 import { Subscription } from 'rxjs';
 
-import { DOCUMENT } from '@angular/common';
 import {
   AfterViewInit,
   Component,
   ElementRef,
   HostListener,
-  Inject,
   Input,
   OnDestroy,
   Renderer2,
+  OnInit,
 } from '@angular/core';
 
 import { IEvent, LIGHTBOX_EVENT, LightboxEvent } from './lightbox-event.service';
@@ -21,16 +20,16 @@ import { IEvent, LIGHTBOX_EVENT, LightboxEvent } from './lightbox-event.service'
     '[class]': 'classList'
   }
 })
-export class LightboxOverlayComponent implements AfterViewInit, OnDestroy {
+export class LightboxOverlayComponent implements OnInit, AfterViewInit, OnDestroy {
   @Input() options: any;
   @Input() cmpRef: any;
   public classList;
   private _subscription: Subscription;
+  private _documentRef: Document;
   constructor(
     private _elemRef: ElementRef,
     private _rendererRef: Renderer2,
-    private _lightboxEvent: LightboxEvent,
-    @Inject(DOCUMENT) private _documentRef: Document
+    private _lightboxEvent: LightboxEvent
   ) {
     this.classList = 'lightboxOverlay animation fadeInOverlay';
     this._subscription = this._lightboxEvent.lightboxEvent$.subscribe((event: IEvent) => this._onReceivedEvent(event));
@@ -40,6 +39,10 @@ export class LightboxOverlayComponent implements AfterViewInit, OnDestroy {
   public close(): void {
     // broadcast to itself and all others subscriber including the components
     this._lightboxEvent.broadcastLightboxEvent({ id: LIGHTBOX_EVENT.CLOSE, data: null });
+  }
+
+  ngOnInit() {
+    this._documentRef = window.document;
   }
 
   public ngAfterViewInit(): void {

--- a/src/lightbox-overlay.component.ts
+++ b/src/lightbox-overlay.component.ts
@@ -7,8 +7,7 @@ import {
   HostListener,
   Input,
   OnDestroy,
-  Renderer2,
-  OnInit,
+  Renderer2
 } from '@angular/core';
 
 import { IEvent, LIGHTBOX_EVENT, LightboxEvent } from './lightbox-event.service';
@@ -20,7 +19,7 @@ import { IEvent, LIGHTBOX_EVENT, LightboxEvent } from './lightbox-event.service'
     '[class]': 'classList'
   }
 })
-export class LightboxOverlayComponent implements OnInit, AfterViewInit, OnDestroy {
+export class LightboxOverlayComponent implements AfterViewInit, OnDestroy {
   @Input() options: any;
   @Input() cmpRef: any;
   public classList;
@@ -33,16 +32,13 @@ export class LightboxOverlayComponent implements OnInit, AfterViewInit, OnDestro
   ) {
     this.classList = 'lightboxOverlay animation fadeInOverlay';
     this._subscription = this._lightboxEvent.lightboxEvent$.subscribe((event: IEvent) => this._onReceivedEvent(event));
+    this._documentRef = window.document;
   }
 
   @HostListener('click')
   public close(): void {
     // broadcast to itself and all others subscriber including the components
     this._lightboxEvent.broadcastLightboxEvent({ id: LIGHTBOX_EVENT.CLOSE, data: null });
-  }
-
-  ngOnInit() {
-    this._documentRef = window.document;
   }
 
   public ngAfterViewInit(): void {

--- a/src/lightbox.component.ts
+++ b/src/lightbox.component.ts
@@ -114,10 +114,10 @@ export class LightboxComponent implements OnInit, AfterViewInit, OnDestroy, OnIn
     this._lightboxElem = this._elemRef;
     this._event.subscription = this._lightboxEvent.lightboxEvent$
       .subscribe((event: IEvent) => this._onReceivedEvent(event));
+    this._documentRef = window.document;
   }
 
   ngOnInit(): void {
-    this._documentRef = window.document;
     this.album.forEach(album => {
       if (album.caption) {
         album.caption = this._sanitizer.sanitize(SecurityContext.HTML, album.caption);

--- a/src/lightbox.component.ts
+++ b/src/lightbox.component.ts
@@ -1,9 +1,7 @@
-import { DOCUMENT } from '@angular/common';
 import {
   AfterViewInit,
   Component,
   ElementRef,
-  Inject,
   Input,
   OnDestroy,
   OnInit,
@@ -53,7 +51,7 @@ import {
     '[class]': 'ui.classList'
   }
 })
-export class LightboxComponent implements AfterViewInit, OnDestroy, OnInit {
+export class LightboxComponent implements OnInit, AfterViewInit, OnDestroy, OnInit {
   @Input() album: Array<IAlbum>;
   @Input() currentImageIndex: number;
   @Input() options: any;
@@ -72,14 +70,14 @@ export class LightboxComponent implements AfterViewInit, OnDestroy, OnInit {
   private _cssValue: any;
   private _event: any;
   private _windowRef: any;
+  private _documentRef: Document;
   constructor(
     private _elemRef: ElementRef,
     private _rendererRef: Renderer2,
     private _lightboxEvent: LightboxEvent,
     public _lightboxElem: ElementRef,
     private _lightboxWindowRef: LightboxWindowRef,
-    private _sanitizer: DomSanitizer,
-    @Inject(DOCUMENT) private _documentRef: Document
+    private _sanitizer: DomSanitizer
   ) {
     // initialize data
     this.options = this.options || {};
@@ -118,7 +116,8 @@ export class LightboxComponent implements AfterViewInit, OnDestroy, OnInit {
       .subscribe((event: IEvent) => this._onReceivedEvent(event));
   }
 
-  public ngOnInit(): void {
+  ngOnInit(): void {
+    this._documentRef = window.document;
     this.album.forEach(album => {
       if (album.caption) {
         album.caption = this._sanitizer.sanitize(SecurityContext.HTML, album.caption);

--- a/src/lightbox.service.ts
+++ b/src/lightbox.service.ts
@@ -2,11 +2,9 @@ import {
   ApplicationRef,
   ComponentFactoryResolver,
   ComponentRef,
-  Inject,
   Injectable,
   Injector
 } from '@angular/core';
-import { DOCUMENT } from '@angular/common';
 import { LightboxComponent } from './lightbox.component';
 import { LightboxConfig } from './lightbox-config.service';
 import { LightboxEvent, LIGHTBOX_EVENT, IAlbum } from './lightbox-event.service';
@@ -14,14 +12,17 @@ import { LightboxOverlayComponent } from './lightbox-overlay.component';
 
 @Injectable()
 export class Lightbox {
+  private _documentRef: Document;
   constructor(
     private _componentFactoryResolver: ComponentFactoryResolver,
     private _injector: Injector,
     private _applicationRef: ApplicationRef,
     private _lightboxConfig: LightboxConfig,
-    private _lightboxEvent: LightboxEvent,
-    @Inject(DOCUMENT) private _documentRef: Document
-  ) {}
+    private _lightboxEvent: LightboxEvent
+
+  ) {
+    this._documentRef = window.document;
+  }
 
   open(album: Array<IAlbum>, curIndex = 0, options = {}): void {
     const overlayComponentRef = this._createComponent(LightboxOverlayComponent);


### PR DESCRIPTION
This PR references #25 and corrects it by referencing the document object directly from the window as opposed to using Angulars injection token which basically resolves to the same thing. In addition, for this to work with Angular Universal, you need to have a global window object defined in your `server.js` (the one in your Angular project derived from initiating an ssr project using Angular Universal) using any `window` npm lib like [window](https://www.npmjs.com/package/window) or [domino](https://www.npmjs.com/package/domino).

Add the below to your `server.js`

```js
global['window'] = window;
```