### PR TITLE
Fix issue #61 - view generation exception when using zoom or rotate o…

### DIFF
--- a/demo/app.component.ts
+++ b/demo/app.component.ts
@@ -55,7 +55,9 @@ export class AppComponent {
     this._lightbox.open(this.albums, index, {
       wrapAround: true,
       showImageNumberLabel: true,
-      disableScrolling: true
+      disableScrolling: true,
+      showZoom: true,
+      showRotate: true
     });
   }
 

--- a/src/lightbox.component.ts
+++ b/src/lightbox.component.ts
@@ -439,9 +439,11 @@ export class LightboxComponent implements OnInit, AfterViewInit, OnDestroy, OnIn
     // position the image according to user's option
     this._positionLightBox();
 
-    // update Controls visibility
-    this.ui.showZoomButton = this.options.showZoom;
-    this.ui.showRotateButton = this.options.showRotate;
+    // update controls visibility on next view generation
+    setTimeout(() => {
+      this.ui.showZoomButton = this.options.showZoom;
+      this.ui.showRotateButton = this.options.showRotate;
+    }, 0);
   }
 
   private _positionLightBox(): void {


### PR DESCRIPTION
Fix issue with view generation when using zoom or rotate options
As per https://github.com/themyth92/ngx-lightbox/issues/61

The view generation throws an exception when using showZoom or showRotate.
Solution for now is to queue changes to showZoomButton/showRotateButton for the next cycle of view generation by using setTimeout(0).