### PR TITLE
Add possibility to define parent element for lightboxes

### DIFF
--- a/src/lightbox-config.service.ts
+++ b/src/lightbox-config.service.ts
@@ -16,6 +16,8 @@ export class LightboxConfig {
   public albumLabel: string;
   public showZoom: boolean;
   public showRotate: boolean;
+  public containerElementResolver: (document: Document) => HTMLElement;
+
   constructor() {
     this.fadeDuration = 0.7;
     this.resizeDuration = 0.5;
@@ -31,5 +33,6 @@ export class LightboxConfig {
     this.albumLabel = 'Image %1 of %2';
     this.showZoom = false;
     this.showRotate = false;
+    this.containerElementResolver = (documentRef) => documentRef.querySelector('body');
   }
 }

--- a/src/lightbox-overlay.component.ts
+++ b/src/lightbox-overlay.component.ts
@@ -5,12 +5,14 @@ import {
   Component,
   ElementRef,
   HostListener,
+  Inject,
   Input,
   OnDestroy,
   Renderer2
 } from '@angular/core';
 
 import { IEvent, LIGHTBOX_EVENT, LightboxEvent } from './lightbox-event.service';
+import { DOCUMENT } from '@angular/common';
 
 @Component({
   selector: '[lb-overlay]',
@@ -24,15 +26,14 @@ export class LightboxOverlayComponent implements AfterViewInit, OnDestroy {
   @Input() cmpRef: any;
   public classList;
   private _subscription: Subscription;
-  private _documentRef: Document;
   constructor(
     private _elemRef: ElementRef,
     private _rendererRef: Renderer2,
-    private _lightboxEvent: LightboxEvent
+    private _lightboxEvent: LightboxEvent,
+    @Inject(DOCUMENT) private _documentRef: Document,
   ) {
     this.classList = 'lightboxOverlay animation fadeInOverlay';
     this._subscription = this._lightboxEvent.lightboxEvent$.subscribe((event: IEvent) => this._onReceivedEvent(event));
-    this._documentRef = window.document;
   }
 
   @HostListener('click')

--- a/src/lightbox.component.spec.ts
+++ b/src/lightbox.component.spec.ts
@@ -52,6 +52,8 @@ describe('[ Unit - LightboxComponent ]', () => {
       showArrowNav: false,
       showPageNumber: false,
       showCaption: false,
+      showZoomButton: false,
+      showRotateButton: false,
       classList: 'lightbox animation fadeIn'
     });
     expect(fixture.componentInstance.content).toEqual({ pageNumber: '' });
@@ -109,6 +111,8 @@ describe('[ Unit - LightboxComponent ]', () => {
         showRightArrow: false,
         showArrowNav: false,
         showPageNumber: false,
+        showZoomButton: false,
+        showRotateButton: false,
         showCaption: false,
         classList: 'lightbox animation fadeIn'
       });
@@ -123,6 +127,8 @@ describe('[ Unit - LightboxComponent ]', () => {
       expect(fixture.componentInstance.ui).toEqual({
         showReloader: true,
         showLeftArrow: false,
+        showZoomButton: false,
+        showRotateButton: false,
         showRightArrow: false,
         showArrowNav: false,
         showPageNumber: false,
@@ -144,6 +150,8 @@ describe('[ Unit - LightboxComponent ]', () => {
         showLeftArrow: false,
         showRightArrow: false,
         showArrowNav: false,
+        showZoomButton: false,
+        showRotateButton: false,
         showPageNumber: false,
         showCaption: false,
         classList: 'lightbox animation fadeIn'
@@ -162,6 +170,8 @@ describe('[ Unit - LightboxComponent ]', () => {
         showReloader: true,
         showLeftArrow: false,
         showRightArrow: false,
+        showZoomButton: false,
+        showRotateButton: false,
         showArrowNav: false,
         showPageNumber: false,
         showCaption: false,

--- a/src/lightbox.component.ts
+++ b/src/lightbox.component.ts
@@ -1,7 +1,9 @@
+import { DOCUMENT } from '@angular/common';
 import {
   AfterViewInit,
   Component,
   ElementRef,
+  Inject,
   Input,
   OnDestroy,
   OnInit,
@@ -23,7 +25,12 @@ import {
   template: `
     <div class="lb-outerContainer transition" #outerContainer id="outerContainer">
       <div class="lb-container" #container id="container">
-        <img class="lb-image" id="image" [src]="album[currentImageIndex].src" class="lb-image animation fadeIn" [hidden]="ui.showReloader" #image>
+        <img class="lb-image"
+             id="image"
+             [src]="album[currentImageIndex].src"
+             class="lb-image animation fadeIn"
+             [hidden]="ui.showReloader"
+             #image>
         <div class="lb-nav" [hidden]="!ui.showArrowNav" #navArrow>
           <a class="lb-prev" [hidden]="!ui.showLeftArrow" (click)="prevImage()" #leftArrow></a>
           <a class="lb-next" [hidden]="!ui.showRightArrow" (click)="nextImage()" #rightArrow></a>
@@ -80,7 +87,6 @@ export class LightboxComponent implements OnInit, AfterViewInit, OnDestroy, OnIn
   private _cssValue: any;
   private _event: any;
   private _windowRef: any;
-  private _documentRef: Document;
   private rotate: number;
   constructor(
     private _elemRef: ElementRef,
@@ -88,7 +94,8 @@ export class LightboxComponent implements OnInit, AfterViewInit, OnDestroy, OnIn
     private _lightboxEvent: LightboxEvent,
     public _lightboxElem: ElementRef,
     private _lightboxWindowRef: LightboxWindowRef,
-    private _sanitizer: DomSanitizer
+    private _sanitizer: DomSanitizer,
+    @Inject(DOCUMENT) private _documentRef: Document
   ) {
     // initialize data
     this.options = this.options || {};
@@ -110,7 +117,7 @@ export class LightboxComponent implements OnInit, AfterViewInit, OnDestroy, OnIn
       showRightArrow: false,
       showArrowNav: false,
 
-      //control the appear of the zoom and rotate buttons
+      // control the appear of the zoom and rotate buttons
       showZoomButton: false,
       showRotateButton: false,
 
@@ -129,7 +136,6 @@ export class LightboxComponent implements OnInit, AfterViewInit, OnDestroy, OnIn
     this._lightboxElem = this._elemRef;
     this._event.subscription = this._lightboxEvent.lightboxEvent$
       .subscribe((event: IEvent) => this._onReceivedEvent(event));
-    this._documentRef = window.document;
     this.rotate = 0;
   }
 
@@ -181,6 +187,8 @@ export class LightboxComponent implements OnInit, AfterViewInit, OnDestroy, OnIn
 
   public control($event: any): void {
     $event.stopPropagation();
+    let height: number;
+    let width: number;
     if ($event.target.classList.contains('lb-turnLeft')) {
       this.rotate = this.rotate - 90;
       this._rotateContainer();
@@ -196,33 +204,34 @@ export class LightboxComponent implements OnInit, AfterViewInit, OnDestroy, OnIn
       document.getElementById('image').style.webkitTransform = `rotate(${this.rotate}deg)`;
       this._lightboxEvent.broadcastLightboxEvent({ id: LIGHTBOX_EVENT.ROTATE_RIGHT, data: null });
     } else if ($event.target.classList.contains('lb-zoomOut')) {
-      var height = parseInt(document.getElementById('outerContainer').style.height) / 1.5;
-      var width = parseInt(document.getElementById('outerContainer').style.width) / 1.5;
-      document.getElementById('outerContainer').style.height = height + "px";
-      document.getElementById('outerContainer').style.width = width + "px";
-      var height = parseInt(document.getElementById('image').style.height) / 1.5;
-      var width = parseInt(document.getElementById('image').style.width) / 1.5;
-      document.getElementById('image').style.height = height + "px";
-      document.getElementById('image').style.width = width + "px";
+      height = parseInt(document.getElementById('outerContainer').style.height, 10) / 1.5;
+      width = parseInt(document.getElementById('outerContainer').style.width, 10) / 1.5;
+      document.getElementById('outerContainer').style.height = height + 'px';
+      document.getElementById('outerContainer').style.width = width + 'px';
+      height = parseInt(document.getElementById('image').style.height, 10) / 1.5;
+      width = parseInt(document.getElementById('image').style.width, 10) / 1.5;
+      document.getElementById('image').style.height = height + 'px';
+      document.getElementById('image').style.width = width + 'px';
       this._lightboxEvent.broadcastLightboxEvent({ id: LIGHTBOX_EVENT.ZOOM_OUT, data: null });
     } else if ($event.target.classList.contains('lb-zoomIn')) {
-      var height = parseInt(document.getElementById('outerContainer').style.height) * 1.5;
-      var width = parseInt(document.getElementById('outerContainer').style.width) * 1.5;
-      document.getElementById('outerContainer').style.height = height + "px";
-      document.getElementById('outerContainer').style.width = width + "px";
-      var height = parseInt(document.getElementById('image').style.height) * 1.5;
-      var width = parseInt(document.getElementById('image').style.width) * 1.5;
-      document.getElementById('image').style.height = height + "px";
-      document.getElementById('image').style.width = width + "px";
+      height = parseInt(document.getElementById('outerContainer').style.height, 10) * 1.5;
+      width = parseInt(document.getElementById('outerContainer').style.width, 10) * 1.5;
+      document.getElementById('outerContainer').style.height = height + 'px';
+      document.getElementById('outerContainer').style.width = width + 'px';
+      height = parseInt(document.getElementById('image').style.height, 10) * 1.5;
+      width = parseInt(document.getElementById('image').style.width, 10) * 1.5;
+      document.getElementById('image').style.height = height + 'px';
+      document.getElementById('image').style.width = width + 'px';
       this._lightboxEvent.broadcastLightboxEvent({ id: LIGHTBOX_EVENT.ZOOM_IN, data: null });
     }
   }
 
   private _rotateContainer(): void {
     let temp = this.rotate;
-    if (temp < 0)
+    if (temp < 0) {
       temp *= -1;
-    if (temp / 90 % 4 == 1 || temp / 90 % 4 == 3) {
+    }
+    if (temp / 90 % 4 === 1 || temp / 90 % 4 === 3) {
       document.getElementById('outerContainer').style.height = document.getElementById('image').style.width;
       document.getElementById('outerContainer').style.width = document.getElementById('image').style.height;
       document.getElementById('container').style.height = document.getElementById('image').style.width;
@@ -242,17 +251,19 @@ export class LightboxComponent implements OnInit, AfterViewInit, OnDestroy, OnIn
   }
 
   private _calcTransformPoint(): void {
-    var height = parseInt(document.getElementById('image').style.height);
-    var width = parseInt(document.getElementById('image').style.width);
-    var temp = this.rotate % 360;
-    if (temp < 0)
+    let height = parseInt(document.getElementById('image').style.height, 10);
+    let width = parseInt(document.getElementById('image').style.width, 10);
+    let temp = this.rotate % 360;
+    if (temp < 0) {
       temp = 360 + temp;
-    if (temp == 90)
-      document.getElementById('image').style.transformOrigin = (height / 2) + "px " + (height / 2) + "px";
-    else if (temp == 180)
-      document.getElementById('image').style.transformOrigin = (width / 2) + "px " + (height / 2) + "px";
-    else if (temp == 270)
-      document.getElementById('image').style.transformOrigin = (width / 2) + "px " + (width / 2) + "px";
+    }
+    if (temp === 90) {
+      document.getElementById('image').style.transformOrigin = (height / 2) + 'px ' + (height / 2) + 'px';
+    } else if (temp === 180) {
+      document.getElementById('image').style.transformOrigin = (width / 2) + 'px ' + (height / 2) + 'px';
+ } else if (temp === 270) {
+      document.getElementById('image').style.transformOrigin = (width / 2) + 'px ' + (width / 2) + 'px';
+ }
   }
 
   public nextImage(): void {

--- a/src/lightbox.service.ts
+++ b/src/lightbox.service.ts
@@ -2,6 +2,7 @@ import {
   ApplicationRef,
   ComponentFactoryResolver,
   ComponentRef,
+  Inject,
   Injectable,
   Injector
 } from '@angular/core';
@@ -9,25 +10,23 @@ import { LightboxComponent } from './lightbox.component';
 import { LightboxConfig } from './lightbox-config.service';
 import { LightboxEvent, LIGHTBOX_EVENT, IAlbum } from './lightbox-event.service';
 import { LightboxOverlayComponent } from './lightbox-overlay.component';
+import { DOCUMENT } from '@angular/common';
 
 @Injectable()
 export class Lightbox {
-  private _documentRef: Document;
   constructor(
     private _componentFactoryResolver: ComponentFactoryResolver,
     private _injector: Injector,
     private _applicationRef: ApplicationRef,
     private _lightboxConfig: LightboxConfig,
-    private _lightboxEvent: LightboxEvent
-
-  ) {
-    this._documentRef = window.document;
-  }
+    private _lightboxEvent: LightboxEvent,
+    @Inject(DOCUMENT) private _documentRef: Document
+  ) { }
 
   open(album: Array<IAlbum>, curIndex = 0, options = {}): void {
     const overlayComponentRef = this._createComponent(LightboxOverlayComponent);
     const componentRef = this._createComponent(LightboxComponent);
-    const newOptions = {};
+    const newOptions: Partial<LightboxConfig> = {};
 
     // broadcast open event
     this._lightboxEvent.broadcastLightboxEvent({ id: LIGHTBOX_EVENT.OPEN });
@@ -56,8 +55,9 @@ export class Lightbox {
         this._applicationRef.detachView(componentRef.hostView);
       });
 
-      this._documentRef.querySelector('body').appendChild(overlayComponentRef.location.nativeElement);
-      this._documentRef.querySelector('body').appendChild(componentRef.location.nativeElement);
+      const containerElement = newOptions.containerElementResolver(this._documentRef);
+      containerElement.appendChild(overlayComponentRef.location.nativeElement);
+      containerElement.appendChild(componentRef.location.nativeElement);
     });
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4245,10 +4245,10 @@ next-tick@^1.0.0:
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
   integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
-ngx-lightbox@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/ngx-lightbox/-/ngx-lightbox-2.0.1.tgz#7e2d358da816a913b63a1e5b0bf96477eead8c32"
-  integrity sha512-/NBf70H47/zYvxtR8fnJgnG0N7LS+V4j92MC/gTibyp78DF4wTR9i3WA2Ox6lKTP0E5CVHg1NqQS8FyWqW/QPw==
+ngx-lightbox@^2.1.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/ngx-lightbox/-/ngx-lightbox-2.2.2.tgz#09b020655e449ca82a68c9438c937f5922f9efea"
+  integrity sha512-H6UYyWEemVh19DPs6afnGK1Bh4368SIt42LB2xKBAr7zNOdIvjmLv/p67KU4nvt+rOkEY1+QiQuNaxRNZRs75Q==
 
 nice-try@^1.0.4:
   version "1.0.5"


### PR DESCRIPTION
# Background information

We want to use ngx-lightbox in combination with web components. These web components are being hosted with isolated JS and CSS, meaning that the outside host does not know anything about the ngx-lightbox and it's styling/logic when rendering the custom HTML element.

This requires the need to define the shadow dom root element as parent element when hosting the lightbox element. Only then the web component can ensure that it also applies the lightbox styling, because it would otherwise need to apply the styles to the body element, which is against the isolated styles rule.

# Pull request details
I hope I could explain this scenario well enough to make you understand the core changes:

1. Changes in `src/lightbox-config.service.ts`
    - Added a new property `containerElementResolver` used by the `LightBoxService` to determine the parent element. Default is "document.body", as it was before, to not break projects relying on older releases.
2. Changes in `src/lightbox.service.ts`
    -  Changed `window.document` usage to `@Inject(DOCUMENT)` import in the constructor. This ensures your framework will work in `@angular/universal` and avoids global objects usage, which is a bad practice.
    - Change `document.querySelector('body')` to use the new property of the `LightBoxConfigService`.
3. Other Changes:
    -  Changed `window.document` usage everywhere to `@Inject(DOCUMENT)` import in the constructor. This ensures your framework will work in `@angular/universal` and avoids global objects usage, which is a bad practice.
    - All other changes are related to unit tests and linting, as they were broken in master and our internal policy requires them to work.

# Timing
As this is required for a release of our products, we would love to see the merge as soon as possible <3.