### PR TITLE
fix: base64 encoded image download filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Each `object` of `album` array inside your component may contains 3 properties :
 | src        | Required    | The source image to your thumbnail that you want to with use lightbox when user click on `thumbnail` image         |
 | caption    | Optional    | Your caption corresponding with your image                                                                         |
 | thumb      | Optional    | Source of your thumbnail. It is being used inside your component markup so this properties depends on your naming. |
+| fileName   | Optional    | The downloaded file name. ex: file1.png                                                                            |
 
 3. Listen to lightbox event
 

--- a/src/lightbox-event.service.ts
+++ b/src/lightbox-event.service.ts
@@ -8,9 +8,14 @@ export interface IEvent {
 }
 
 export interface IAlbum {
+  /** The source image to your thumbnail that you want to with use lightbox when user click on thumbnail image */
   src: string;
+  /** Your caption corresponding with your image */
   caption?: string;
+  /** Source of your thumbnail. It is being used inside your component markup so this properties depends on your naming. */
   thumb: string;
+  /** The downloaded file name. ex: file1.png */
+  fileName?: string;
 }
 
 export const LIGHTBOX_EVENT = {

--- a/src/lightbox.component.ts
+++ b/src/lightbox.component.ts
@@ -199,8 +199,12 @@ export class LightboxComponent implements OnInit, AfterViewInit, OnDestroy, OnIn
   public download($event: any): void {
     $event.stopPropagation();
     const url = this.album[this.currentImageIndex].src;
-    const parts = url.split('/');
-    const fileName = parts[parts.length - 1];
+    if (this.album[this.currentImageIndex].fileName != undefined) {
+      var fileName = this.album[this.currentImageIndex].fileName;
+    } else {
+      const parts = url.split('/');
+      var fileName = parts[parts.length - 1];
+    }
 
     this._http.get(url, {
       responseType: 'blob'


### PR DESCRIPTION
I was using base64 encoded image strings, and when trying to download the picture, the parsing currently in place does not work.

ex: self hosted - http://example.com/file1.png
filename = file1.png
ex: base64 encoded - data:image/jpg;base64,/9j/....
filename = some characters at the end of the last forward slash.

I propose adding an additional argument to the IAlbum interface called fileName, to allow users to override the default attempt of naming downloaded files.