### PR TITLE
Override download Url

### DIFF
--- a/src/lightbox-event.service.ts
+++ b/src/lightbox-event.service.ts
@@ -11,6 +11,7 @@ export interface IAlbum {
   src: string;
   caption?: string;
   thumb: string;
+  downloadUrl: string;
 }
 
 export const LIGHTBOX_EVENT = {

--- a/src/lightbox.component.ts
+++ b/src/lightbox.component.ts
@@ -197,6 +197,7 @@ export class LightboxComponent implements OnInit, AfterViewInit, OnDestroy, OnIn
   public download($event: any): void {
     $event.stopPropagation();
     const url = this.album[this.currentImageIndex].src;
+    const downloadUrl = this.album[this.currentImageIndex].downloadUrl;
     const parts = url.split('/');
     const fileName = parts[parts.length - 1];
     const canvas = document.createElement('canvas');
@@ -217,7 +218,10 @@ export class LightboxComponent implements OnInit, AfterViewInit, OnDestroy, OnIn
       }, 'image/jpeg', 0.75);
     };
     preloader.crossOrigin = '';
-    preloader.src = this._sanitizer.sanitize(SecurityContext.URL, url);
+    if(downloadUrl && downloadUrl.length > 0)
+      preloader.src = this._sanitizer.sanitize(SecurityContext.URL, downloadUrl);
+    else
+      preloader.src = this._sanitizer.sanitize(SecurityContext.URL, url);
   }
 
   public control($event: any): void {


### PR DESCRIPTION
This is a suggested mechanism for allowing the developer to override the download url by introducing a "downloadUrl" property which when populated gets used instead of the src property.