### PR TITLE
fix(album): make downloadUrl optional

### DIFF
--- a/src/lightbox-event.service.ts
+++ b/src/lightbox-event.service.ts
@@ -11,7 +11,7 @@ export interface IAlbum {
   src: string;
   caption?: string;
   thumb: string;
-  downloadUrl: string;
+  downloadUrl?: string;
 }
 
 export const LIGHTBOX_EVENT = {


### PR DESCRIPTION
Fix typing issue in `IAlbum` interface, the `downloadUrl` prop should be optional.